### PR TITLE
PKGBUILD

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,31 @@
+# Maintainer: Antony Kellermann <aokellermann@gmail.com>
+
+_pkgname=iex
+pkgname="${_pkgname}-git"
+pkgver=0.0.1
+pkgrel=1
+pkgdesc="C++17 library for querying IEX Cloud API."
+arch=('x86_64')
+url="https://github.com/aokellermann/${_pkgname}"
+license=('MIT')
+depends=('curl' 'nlohmann-json')
+makedepends=("cmake")
+provides=("${_pkgname}")
+conflicts=("${_pkgname}")
+source=("git://github.com/aokellermann/${_pkgname}")
+md5sums=('SKIP')
+
+prepare() {
+  mkdir -p "${_pkgname}/build"
+}
+
+build() {
+  cd "${_pkgname}/build" || exit 1
+  cmake -DCMAKE_INSTALL_PREFIX=/usr ..
+  cmake --build .
+}
+
+package() {
+  cmake --build "${_pkgname}/build" --target install -- DESTDIR="${pkgdir}"
+  install -Dm644 "${_pkgname}/LICENSE" "${pkgdir}/usr/share/licenses/${_pkgname}/LICENSE"
+}

--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@ iex is a WIP C++17 library for querying [IEX Cloud](https://iexcloud.io/), a fin
 
 ### Install
 
+#### Arch Linux Package
+Arch Linux users may install with the included `PKGBUILD`:
+```bash
+mkdir build && cd build
+wget https://raw.githubusercontent.com/aokellermann/iex/master/PKGBUILD
+makepkg -si
+```
+
 #### Manual Build
 
 ##### Dependencies


### PR DESCRIPTION
### Changes
* Adds `PKGBUILD` for Arch Linux users.
* Includes documentation in `README` for using `PKGBUILD`.
* Closes #5

### Additional Context
* This `PKGBUILD` has package name `iex-git` due to it pulling source directly from master, rather than a release. Once the library is implemented, it will be changed.
