### PR TITLE
Clang format Include regroup

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -65,7 +65,7 @@ ForEachMacros:
   - foreach
   - Q_FOREACH
   - BOOST_FOREACH
-IncludeBlocks:   Preserve
+IncludeBlocks:   Regroup
 IncludeCategories:
   - Regex:           '^<ext/.*\.h>'
     Priority:        2

--- a/iex/test/unit_test.cc
+++ b/iex/test/unit_test.cc
@@ -15,12 +15,13 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
+#include <gtest/gtest.h>
+
 #include <mutex>
 #include <thread>
 #include <unordered_set>
 #include <vector>
 
-#include <gtest/gtest.h>  // NOLINT Why does linter think this is a C library?
 #include "iex/iex.h"
 #include "iex/singleton.h"
 


### PR DESCRIPTION
### Changes
* Changed IncludeBlocks in .clang-format to Regroup.
* Fixed nonforming code.
* Closes #24.