### PR TITLE
Use archlinux docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,13 @@ version: 2
 jobs:
   build:
     docker:
-      - image: aokellermann/iex:ci
-        auth:
-          username: aokellermann
-          password: $DOCKERHUB_PASSWORD
+      - image: archlinux
+
     steps:
       - checkout
+      - run:
+          name: Install required tools
+          command: pacman -Sy --noconfirm base base-devel cmake clang git curl nlohmann-json doxygen
       - run:
           name: Configure
           command: |


### PR DESCRIPTION
### Changes
* Uses public arch linux docker image for CircleCI.
* Installs all tools (such as C++ compiler) before build.

### Additional Context
* Since API keys can be set from CircleCI, image doesn't need to be private.
